### PR TITLE
Add boilerplate vote config, steering committee files

### DIFF
--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -83,9 +83,9 @@ profiles:
     #     - cynthia-sg
     #     - tegioz
     #
-    allowed_voters:
-      teams: []
-      users: []
+    # allowed_voters:
+    #  teams: []
+    #  users: []
 
   # Additional configuration profiles
   #
@@ -98,9 +98,9 @@ profiles:
   # profile is used when using the /vote command, but its values are not used as
   # default values when they are not provided on other profiles.
   #
-  profile1:
-    duration: 1m
-    pass_threshold: 75
-    allowed_voters:
-      teams:
-        - team1
+  # profile1:
+  #  duration: 1m
+  #  pass_threshold: 75
+  #  allowed_voters:
+  #    teams:
+  #      - team1

--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -1,0 +1,106 @@
+# GitVote configuration file
+#
+# GitVote will look for it in the following locations (in order of precedence):
+#
+#   - At the root of the repository where the vote was created
+#   - At the root of the .github repository, for organization wide configuration
+#
+
+# Automation (optional)
+#
+# Create votes automatically on PRs when any of the files affected by the PR
+# match any of the patterns provided. Patterns must follow the gitignore
+# format (https://git-scm.com/docs/gitignore#_pattern_format).
+#
+# Each automation rule must include a list of patterns and the profile to use
+# when creating the vote. This allows creating votes automatically using the
+# desired configuration based on the patterns matched. Rules are processed in
+# the order provided, and the first match wins.
+#
+# automation:
+#   enabled: true
+#   rules:
+#     - patterns:
+#         - "README.md"
+#         - "*.txt"
+#       profile: default
+#
+automation:
+  enabled: false
+  rules:
+    - patterns: []
+      profile: profile1
+
+# Configuration profiles (required)
+#
+# A configuration profile defines some properties of a vote, like its duration,
+# the pass threshold or the users who have a binding vote. It's possible to
+# define multiple configuration profiles, each with a different set of settings.
+#
+profiles:
+  # Default configuration profile
+  #
+  # This profile will be used with votes created with the /vote command
+  default:
+    # Voting duration (required)
+    #
+    # How long the vote will be open
+    #
+    # Units supported (can be combined as in 1hour 30mins):
+    #
+    #   minutes | minute | mins | min | m
+    #   hours   | hour   | hrs  | hrs | h
+    #   days    | day    | d
+    #   weeks   | week   | w
+    #
+    duration: 5m
+
+    # Pass threshold (required)
+    #
+    # Percentage of votes in favor required to pass the vote
+    #
+    # The percentage is calculated based on the number of votes in favor and the
+    # number of allowed voters (see allowed_voters field below for more details).
+    pass_threshold: 50
+
+    # Allowed voters (optional)
+    #
+    # List of GitHub teams and users who have binding votes
+    #
+    # If no teams or users are provided, all repository collaborators will be
+    # allowed to vote. For organization-owned repositories, the list of
+    # collaborators includes outside collaborators, organization members that are
+    # direct collaborators, organization members with access through team
+    # memberships, organization members with access through default organization
+    # permissions, and organization owners.
+    #
+    # Teams names must be provided without the organization prefix.
+    #
+    # allowed_voters:
+    #   teams:
+    #     - team1
+    #   users:
+    #     - cynthia-sg
+    #     - tegioz
+    #
+    allowed_voters:
+      teams: []
+      users: []
+
+  # Additional configuration profiles
+  #
+  # In addition to the default configuration profile, it is possible to add more
+  # to easily create votes with different settings. To create a vote that uses a
+  # different profile you can use the command /vote-PROFILE. In the case below,
+  # the command would be /vote-profile1
+  #
+  # Please note that each profile must contain all required fields. The default
+  # profile is used when using the /vote command, but its values are not used as
+  # default values when they are not provided on other profiles.
+  #
+  profile1:
+    duration: 1m
+    pass_threshold: 75
+    allowed_voters:
+      teams:
+        - team1

--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -1,0 +1,19 @@
+# Steering Committee
+
+This document lists the members of the Organization's Steering Committee. Voting members may be added once 
+approved by the Steering Committee as described in the [charter](./CHARTER.md). By adding your name to this list 
+you are agreeing to abide by all Organization polices, including the [charter](./CHARTER.md), the [code of 
+conduct](./CODE-OF-CONDUCT.md), the [trademark policy](./TRADEMARKS.md), and the [antitrust 
+policy](./ANTITRUST.md). If you are serving on the Steering Committee because of your affiliation with another 
+organization (designated below), you represent that you have authority to bind that organization to these 
+policies.
+
+| **NAME** | **Handle** | **Affiliated Organization** |
+| --- | --- | --- |
+| [Steering Committee Member] | [handle ] | [affiliation] |
+|  ... | ... | ... |
+
+---
+Part of MVG-0.1-beta.
+Made with love by GitHub. Licensed under the [CC-BY 4.0 
+License](https://creativecommons.org/licenses/by-sa/4.0/).

--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -1,16 +1,21 @@
 # Steering Committee
 
-This document lists the members of the Organization's Steering Committee.
+This document lists the members of the Organization's Governance Drafting Task Force.
 
-Voting members may be added once approved by the Steering Committee as described in
-**(TODO: we're rogue for now! This process should be described in the governance doc that we're writing!)**.
+To be added to this list, a potential member must
+
+1. add their name to this document (see [./README.md](for details about how to do this if you're unfamiliar with git))
+2. submit a pull request
+
+**TWO** currently-sitting task force members must approve the pull request before the member can be added.
+
 By adding your name to this list you are agreeing to abide by all Organization polices, including the existing
 [code of conduct]([./CODE-OF-CONDUCT.md](https://github.com/resbazaz/website/blob/gh-pages/codeOfConduct.md).
 
 | **NAME** | **Github Username** |
 | --- | --- |
 | [Steering Committee Member] | [github username] |
-|  Alex Bigelow | alex-r-bigelow | Stardog |
+|  --- | --- | --- |
 
 ---
 Licensed under the [CC-BY 4.0 

--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -1,19 +1,17 @@
 # Steering Committee
 
-This document lists the members of the Organization's Steering Committee. Voting members may be added once 
-approved by the Steering Committee as described in the [charter](./CHARTER.md). By adding your name to this list 
-you are agreeing to abide by all Organization polices, including the [charter](./CHARTER.md), the [code of 
-conduct](./CODE-OF-CONDUCT.md), the [trademark policy](./TRADEMARKS.md), and the [antitrust 
-policy](./ANTITRUST.md). If you are serving on the Steering Committee because of your affiliation with another 
-organization (designated below), you represent that you have authority to bind that organization to these 
-policies.
+This document lists the members of the Organization's Steering Committee.
 
-| **NAME** | **Handle** | **Affiliated Organization** |
-| --- | --- | --- |
-| [Steering Committee Member] | [handle ] | [affiliation] |
-|  ... | ... | ... |
+Voting members may be added once approved by the Steering Committee as described in
+**(TODO: we're rogue for now! This process should be described in the governance doc that we're writing!)**.
+By adding your name to this list you are agreeing to abide by all Organization polices, including the existing
+[code of conduct]([./CODE-OF-CONDUCT.md](https://github.com/resbazaz/website/blob/gh-pages/codeOfConduct.md).
+
+| **NAME** | **Github Username** |
+| --- | --- |
+| [Steering Committee Member] | [github username] |
+|  Alex Bigelow | alex-r-bigelow | Stardog |
 
 ---
-Part of MVG-0.1-beta.
-Made with love by GitHub. Licensed under the [CC-BY 4.0 
+Licensed under the [CC-BY 4.0 
 License](https://creativecommons.org/licenses/by-sa/4.0/).


### PR DESCRIPTION
Once the `.gitvote.yml` file is finalized, we need to add the [git-vote app](https://github.com/apps/git-vote) to this repository for `/vote` commands to start working