### PR TITLE
Remove the 1-minute window for testing voting

### DIFF
--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -53,7 +53,7 @@ profiles:
     #   days    | day    | d
     #   weeks   | week   | w
     #
-    duration: 1m
+    duration: 1d
 
     # Pass threshold (required)
     #


### PR DESCRIPTION
Is starting with a 1-day closing window sensible? The task force can update this in the future...